### PR TITLE
Replace Python with Anaconda in Docker images

### DIFF
--- a/Dockerfile.caffe-keras-tf
+++ b/Dockerfile.caffe-keras-tf
@@ -17,9 +17,6 @@ RUN apt-get update && apt-get install -y \
   libleveldb-dev \
   liblmdb-dev \
   libsnappy-dev \
-  python-dev \
-  python-pip \
-  python-numpy \
   gfortran > /dev/null
 
 # Clone Caffe repo and move into it
@@ -42,6 +39,7 @@ ENV PYTHONPATH=/root/caffe/python:$PYTHONPATH
 # Set ~/caffe as working directory
 WORKDIR /root/caffe
 
-RUN pip install --upgrade https://storage.googleapis.com/tensorflow/linux/gpu/tensorflow-0.8.0-cp27-none-linux_x86_64.whl && \
+# Install Tensorflow
+# --ignore-installed is required when using Anaconda per: https://github.com/tensorflow/tensorflow/issues/622#issuecomment-170309570
+RUN pip install --upgrade --ignore-installed https://storage.googleapis.com/tensorflow/linux/gpu/tensorflow-0.8.0-cp27-none-linux_x86_64.whl && \
     pip install --upgrade pandas
-

--- a/Dockerfile.nvidia
+++ b/Dockerfile.nvidia
@@ -69,10 +69,59 @@ RUN apt-get update && apt-get install -y --no-install-recommends --force-yes \
 	   libcudnn4-dev=4.0.7 && \
     rm -rf /var/lib/apt/lists/*
 
-# Install Python Tools
-RUN apt-get update && \
-    apt-get install -y python-setuptools python-dev build-essential python-pip && \
-    apt-get install -y git && \
-    apt-get -y install python-scipy python-matplotlib python-pandas python-sympy python-nose && \
-    pip install ipython notebook
+# Install Anaconda
+# From: https://github.com/ContinuumIO/docker-images/tree/master/anaconda
+#
+# Except where noted below, docker-anaconda is released under the following terms:
+# 
+# (c) 2012 Continuum Analytics, Inc. / http://continuum.io
+# All Rights Reserved
+# 
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#     * Redistributions of source code must retain the above copyright
+#       notice, this list of conditions and the following disclaimer.
+#     * Redistributions in binary form must reproduce the above copyright
+#       notice, this list of conditions and the following disclaimer in the
+#       documentation and/or other materials provided with the distribution.
+#     * Neither the name of Continuum Analytics, Inc. nor the
+#       names of its contributors may be used to endorse or promote products
+#       derived from this software without specific prior written permission.
+# 
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+# ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL CONTINUUM ANALYTICS BE LIABLE FOR ANY
+# DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+# (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+# ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+# SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+RUN apt-get update --fix-missing && apt-get install -y wget bzip2 ca-certificates \
+    libglib2.0-0 libxext6 libsm6 libxrender1 \
+    git mercurial subversion
+
+RUN echo 'export PATH=/opt/conda/bin:$PATH' > /etc/profile.d/conda.sh && \
+    wget --quiet https://repo.continuum.io/archive/Anaconda2-4.0.0-Linux-x86_64.sh && \
+    /bin/bash /Anaconda2-4.0.0-Linux-x86_64.sh -b -p /opt/conda && \
+    rm /Anaconda2-4.0.0-Linux-x86_64.sh
+
+RUN apt-get install -y curl grep sed dpkg && \
+    TINI_VERSION=`curl https://github.com/krallin/tini/releases/latest | grep -o "/v.*\"" | sed 's:^..\(.*\).$:\1:'` && \
+    curl -L "https://github.com/krallin/tini/releases/download/v${TINI_VERSION}/tini_${TINI_VERSION}.deb" > tini.deb && \
+    dpkg -i tini.deb && \
+    rm tini.deb && \
+    apt-get clean
+
+ENV PATH /opt/conda/bin:$PATH
+
+# http://bugs.python.org/issue19846
+# > At the moment, setting "LANG=C" on a Linux system *fundamentally breaks Python 3*, and that's not OK.
+ENV LANG C.UTF-8
+
+# Set up build tools
+RUN apt-get update && apt-get install -y --no-install-recommends --force-yes \
+	build-essential && \
+    rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
Anaconda already includes many of the libraries we need, and makes
handling them much easier.