### PR TITLE
Reformat and fixup Dockerfile.nvidia

### DIFF
--- a/Dockerfile.nvidia
+++ b/Dockerfile.nvidia
@@ -2,12 +2,14 @@ FROM ubuntu:14.04
 MAINTAINER Alex Gude
 
 RUN apt-get install module-init-tools -y
+
 # Mount the installer to Docker
 ENV NVIDIA_DRIVER_VERSION 352.68
 LABEL com.nvidia.driver.version="352.68"
+
 RUN apt-get update && apt-get install -y --no-install-recommends --force-yes \
-	    wget && \
-	    rm -rf /var/lib/apt/lists/*
+        wget && \
+    rm -rf /var/lib/apt/lists/*
 
 RUN cd /tmp/ && \
     wget http://us.download.nvidia.com/XFree86/Linux-x86_64/${NVIDIA_DRIVER_VERSION}/NVIDIA-Linux-x86_64-${NVIDIA_DRIVER_VERSION}.run && \
@@ -16,8 +18,10 @@ RUN cd /tmp/ && \
     rm ./NVIDIA-Linux-x86_64-${NVIDIA_DRIVER_VERSION}.run
 
 # Install CUDA
-ENV CUDA_VERSION 7.5
-LABEL com.nvidia.cuda.version="7.5"
+ENV CUDA_VERSION 7.5-18
+LABEL com.nvidia.cuda.version="7.5-18"
+ENV CUDA_PKG_VERSION 7-5=7.5-18
+
 ENV NVIDIA_GPGKEY_SUM bd841d59a27a406e513db7d405550894188a4c1cd96bf8aa4f82f1b39e0b5c1c
 ENV NVIDIA_GPGKEY_FPR 889bee522da690103c4b085ed88c3d385c37d3be
 RUN apt-key adv --fetch-keys http://developer.download.nvidia.com/compute/cuda/repos/GPGKEY && \
@@ -25,58 +29,66 @@ RUN apt-key adv --fetch-keys http://developer.download.nvidia.com/compute/cuda/r
     echo "$NVIDIA_GPGKEY_SUM cudasign.pub" | sha256sum -c --strict - && rm cudasign.pub && \
     echo "deb http://developer.download.nvidia.com/compute/cuda/repos/ubuntu1404/x86_64 /" > /etc/apt/sources.list.d/cuda.list
 
-ENV CUDA_PKG_VERSION 7-5=7.5-18
 RUN apt-get update && apt-get install -y --no-install-recommends --force-yes \
-	    cuda-nvrtc-$CUDA_PKG_VERSION \
-	    cuda-cusolver-$CUDA_PKG_VERSION \
-	    cuda-cublas-$CUDA_PKG_VERSION \
-	    cuda-cufft-$CUDA_PKG_VERSION \
-	    cuda-curand-$CUDA_PKG_VERSION \
-	    cuda-cusparse-$CUDA_PKG_VERSION \
-	    cuda-npp-$CUDA_PKG_VERSION \
-	    cuda-cudart-$CUDA_PKG_VERSION && \
-	    ln -s cuda-$CUDA_VERSION /usr/local/cuda && \
-	    rm -rf /var/lib/apt/lists/*
-	    RUN echo "/usr/local/cuda/lib" >> /etc/ld.so.conf.d/cuda.conf && \
-	    echo "/usr/local/cuda/lib64" >> /etc/ld.so.conf.d/cuda.conf && \
-	    ldconfig
+        cuda-nvrtc-$CUDA_PKG_VERSION \
+        cuda-cusolver-$CUDA_PKG_VERSION \
+        cuda-cublas-$CUDA_PKG_VERSION \
+        cuda-cufft-$CUDA_PKG_VERSION \
+        cuda-curand-$CUDA_PKG_VERSION \
+        cuda-cusparse-$CUDA_PKG_VERSION \
+        cuda-npp-$CUDA_PKG_VERSION \
+        cuda-cudart-$CUDA_PKG_VERSION && \
+    ln -s cuda-$CUDA_VERSION /usr/local/cuda && \
+    rm -rf /var/lib/apt/lists/*
+
+RUN echo "/usr/local/cuda/lib" >> /etc/ld.so.conf.d/cuda.conf && \
+    echo "/usr/local/cuda/lib64" >> /etc/ld.so.conf.d/cuda.conf && \
+    ldconfig
 
 RUN echo "/usr/local/nvidia/lib" >> /etc/ld.so.conf.d/nvidia.conf && \
     echo "/usr/local/nvidia/lib64" >> /etc/ld.so.conf.d/nvidia.conf
 
+ENV PATH /usr/local/nvidia/bin:/usr/local/cuda/bin:${PATH}
+ENV LD_LIBRARY_PATH /usr/local/nvidia/lib:/usr/local/nvidia/lib64:${LD_LIBRARY_PATH}
+
 RUN apt-get update && apt-get install -y --no-install-recommends --force-yes \
-    		cuda-core-$CUDA_PKG_VERSION \
-    		cuda-misc-headers-$CUDA_PKG_VERSION \
-		cuda-command-line-tools-$CUDA_PKG_VERSION \
-		cuda-license-$CUDA_PKG_VERSION \
-		cuda-nvrtc-dev-$CUDA_PKG_VERSION \
-		cuda-cusolver-dev-$CUDA_PKG_VERSION \
-		cuda-cublas-dev-$CUDA_PKG_VERSION \
-		cuda-cufft-dev-$CUDA_PKG_VERSION \
-		cuda-curand-dev-$CUDA_PKG_VERSION \
-		cuda-cusparse-dev-$CUDA_PKG_VERSION \
-		cuda-npp-dev-$CUDA_PKG_VERSION \
-		cuda-cudart-dev-$CUDA_PKG_VERSION \
-		cuda-driver-dev-$CUDA_PKG_VERSION && \
-		rm -rf /var/lib/apt/lists/*
+        cuda-core-$CUDA_PKG_VERSION \
+        cuda-misc-headers-$CUDA_PKG_VERSION \
+        cuda-command-line-tools-$CUDA_PKG_VERSION \
+        cuda-license-$CUDA_PKG_VERSION \
+        cuda-nvrtc-dev-$CUDA_PKG_VERSION \
+        cuda-cusolver-dev-$CUDA_PKG_VERSION \
+        cuda-cublas-dev-$CUDA_PKG_VERSION \
+        cuda-cufft-dev-$CUDA_PKG_VERSION \
+        cuda-curand-dev-$CUDA_PKG_VERSION \
+        cuda-cusparse-dev-$CUDA_PKG_VERSION \
+        cuda-npp-dev-$CUDA_PKG_VERSION \
+        cuda-cudart-dev-$CUDA_PKG_VERSION \
+        cuda-driver-dev-$CUDA_PKG_VERSION && \
+    rm -rf /var/lib/apt/lists/*
 
 # Install cuDNN
-RUN echo "deb http://developer.download.nvidia.com/compute/machine-learning/repos/ubuntu1404/x86_64 /" > /etc/apt/sources.list.d/nvidia-ml.list
 ENV CUDNN_VERSION 4
 LABEL com.nvidia.cudnn.version="4"
+ENV CUDNN_PKG_VERSION 4.0.7
+
+RUN echo "deb http://developer.download.nvidia.com/compute/machine-learning/repos/ubuntu1404/x86_64 /" > /etc/apt/sources.list.d/nvidia-ml.list
+
 RUN apt-get update && apt-get install -y --no-install-recommends --force-yes \
-	   libcudnn4=4.0.7 \
-	   libcudnn4-dev=4.0.7 && \
+        libcudnn4=$CUDNN_PKG_VERSION \
+        libcudnn4-dev=$CUDNN_PKG_VERSION && \
     rm -rf /var/lib/apt/lists/*
+
+ENV LIBRARY_PATH /usr/local/cuda/lib64/stubs:${LIBRARY_PATH}
 
 # Install Anaconda
 # From: https://github.com/ContinuumIO/docker-images/tree/master/anaconda
 #
 # Except where noted below, docker-anaconda is released under the following terms:
-# 
+#
 # (c) 2012 Continuum Analytics, Inc. / http://continuum.io
 # All Rights Reserved
-# 
+#
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions are met:
 #     * Redistributions of source code must retain the above copyright
@@ -87,7 +99,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends --force-yes \
 #     * Neither the name of Continuum Analytics, Inc. nor the
 #       names of its contributors may be used to endorse or promote products
 #       derived from this software without specific prior written permission.
-# 
+#
 # THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
 # ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
 # WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
@@ -123,5 +135,5 @@ ENV LANG C.UTF-8
 
 # Set up build tools
 RUN apt-get update && apt-get install -y --no-install-recommends --force-yes \
-	build-essential && \
+        build-essential && \
     rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
There were a few potential problems and formatting oddities that have
been fixed, including:

- Spacing and indenting of `apt-get` commands
- Indenting of several Docker commands
- Added variables to track exact library versions
- Add several locations to the `$PATH`, `$LD_LIBRARY_PATH`, and
  `$LIBRARY_PATH` variables
- Various spacing and tab related errors