### PR TITLE
Change installation method of cuDNN to use PPAs

### DIFF
--- a/Dockerfile.densecap
+++ b/Dockerfile.densecap
@@ -1,4 +1,3 @@
-
 # Be sure to download cuda from NVIDIA first before building this
 # container. NVIDIA requires users to register as a developer. Afterwards,
 # you can download the .tgz file. 
@@ -56,12 +55,14 @@ RUN luarocks install https://raw.githubusercontent.com/qassemoquab/stnbhwd/maste
 RUN luarocks install https://raw.githubusercontent.com/jcjohnson/torch-rnn/master/torch-rnn-scm-1.rockspec
 RUN luarocks install loadcaffe
 
-# Add NVIDIA's cuDNN 
-RUN mkdir /nvidia_cudnn
-ADD extras/cudnn-7.5-linux-x64-v5.1-rc.tgz /nvidia_cudnn
-RUN sudo cp -P /nvidia_cudnn/cuda/include/cudnn.h /usr/include
-RUN sudo cp -P /nvidia_cudnn/cuda/lib64/libcudnn* /usr/lib/x86_64-linux-gnu/
-RUN sudo chmod a+r /usr/lib/x86_64-linux-gnu/libcudnn*
+# Install cuDNN
+RUN echo "deb http://developer.download.nvidia.com/compute/machine-learning/repos/ubuntu1404/x86_64 /" > /etc/apt/sources.list.d/nvidia-ml.list
+ENV CUDNN_VERSION 5
+LABEL com.nvidia.cudnn.version="5"
+RUN apt-get update && apt-get install -y --no-install-recommends --force-yes \
+        libcudnn5 \
+        libcudnn5-dev && \
+    rm -rf /var/lib/apt/lists/*
 
 # GPU acceleratation
 RUN luarocks install cutorch

--- a/Dockerfile.densecap
+++ b/Dockerfile.densecap
@@ -1,31 +1,29 @@
-# Be sure to download cuda from NVIDIA first before building this
-# container. NVIDIA requires users to register as a developer. Afterwards,
-# you can download the .tgz file. 
-
 FROM  l41-nvidia-base
+
 # Install git, apt-add-repository and dependencies for iTorch
 RUN apt-get update && apt-get install -y \
-  git \
-  software-properties-common \
-  ipython3 \
-  libssl-dev \
-  libzmq3-dev \
-  python-zmq \
-  python-pip \
-  libhdf5-serial-dev \
-  hdf5-tools \
-  libprotobuf-dev \ 
-  protobuf-compiler \
-  default-jre
+    git \
+    software-properties-common \
+    ipython3 \
+    libssl-dev \
+    libzmq3-dev \
+    python-zmq \
+    python-pip \
+    libhdf5-serial-dev \
+    hdf5-tools \
+    libprotobuf-dev \
+    protobuf-compiler \
+    default-jre
 
 # Install Jupyter Notebook for iTorch
 RUN pip install notebook ipywidgets
 
 # Run Torch7 installation scripts (dependencies only)
-RUN git clone https://github.com/torch/distro.git /root/torch --recursive && cd /root/torch && \
-  bash install-deps
+RUN git clone https://github.com/torch/distro.git /root/torch --recursive && \
+    cd /root/torch && \
+    bash install-deps
 RUN cd /root/torch && \
-  ./install.sh
+    ./install.sh
 
 # Export environment variables manually
 ENV LUA_PATH='/root/.luarocks/share/lua/5.1/?.lua;/root/.luarocks/share/lua/5.1/?/init.lua;/root/torch/install/share/lua/5.1/?.lua;/root/torch/install/share/lua/5.1/?/init.lua;./?.lua;/root/torch/install/share/luajit-2.1.0-beta1/?.lua;/usr/local/share/lua/5.1/?.lua;/usr/local/share/lua/5.1/?/init.lua'
@@ -37,14 +35,17 @@ ENV LUA_CPATH='/root/torch/install/lib/?.so;'$LUA_CPATH
 
 # Install cudnn manually as Torch opts for latest version
 #RUN luarocks install https://raw.githubusercontent.com/soumith/cudnn.torch/R4/cudnn-scm-1.rockspec
-RUN cd /root && git clone https://github.com/deepmind/torch-hdf5.git && \
-  cd torch-hdf5 && luarocks make hdf5-0-0.rockspec LIBHDF5_LIBDIR="/usr/lib/x86_64-linux-gnu/"
+RUN cd /root && \
+    git clone https://github.com/deepmind/torch-hdf5.git && \
+    cd torch-hdf5 && \
+    luarocks make hdf5-0-0.rockspec LIBHDF5_LIBDIR="/usr/lib/x86_64-linux-gnu/"
 
 # add FindCUDA to remove annoying warnings
-RUN wget https://github.com/hughperkins/FindCUDA/archive/v3.5-1.tar.gz -q -O FindCUDA-v3.5-1.tar.gz 
-RUN tar -zxf FindCUDA-v3.5-1.tar.gz
-RUN cd FindCUDA-3.5-1 && luarocks make rocks/findcuda-scm-1.rockspec
-RUN rm /FindCUDA-v3.5-1.tar.gz
+RUN wget https://github.com/hughperkins/FindCUDA/archive/v3.5-1.tar.gz -q -O FindCUDA-v3.5-1.tar.gz && \
+    tar -zxf FindCUDA-v3.5-1.tar.gz && \
+    cd FindCUDA-3.5-1 && \
+    luarocks make rocks/findcuda-scm-1.rockspec && \
+    rm /FindCUDA-v3.5-1.tar.gz
 
 # Install additional DenseCap dependencies
 RUN luarocks install torch


### PR DESCRIPTION
This allows users to build the containers without having to sign up for the dev program and download the files by hand.

This should fix #71 .