### PR TITLE
Fix several bugs in Dockerfiles

### DIFF
--- a/Dockerfile.nvidia
+++ b/Dockerfile.nvidia
@@ -18,9 +18,11 @@ RUN cd /tmp/ && \
     rm ./NVIDIA-Linux-x86_64-${NVIDIA_DRIVER_VERSION}.run
 
 # Install CUDA
-ENV CUDA_VERSION 7.5-18
-LABEL com.nvidia.cuda.version="7.5-18"
+# We do not include the patch version number in CUDA_VERSION because it is used
+# to link to the CUDA directory, which excludes the patch
+ENV CUDA_VERSION 7.5
 ENV CUDA_PKG_VERSION 7-5=7.5-18
+LABEL com.nvidia.cuda.version="7.5-18"
 
 ENV NVIDIA_GPGKEY_SUM bd841d59a27a406e513db7d405550894188a4c1cd96bf8aa4f82f1b39e0b5c1c
 ENV NVIDIA_GPGKEY_FPR 889bee522da690103c4b085ed88c3d385c37d3be

--- a/Dockerfile.torch
+++ b/Dockerfile.torch
@@ -2,18 +2,17 @@ FROM  l41-nvidia-base
 
 # Install git, apt-add-repository and dependencies for iTorch
 RUN apt-get update && apt-get install -y \
+    default-jre \
     git \
-    software-properties-common \
-    ipython3 \
-    libssl-dev \
-    libzmq3-dev \
-    python-zmq \
-    python-pip \
-    libhdf5-serial-dev \
     hdf5-tools \
+    ipython3 \
+    libhdf5-serial-dev \
     libprotobuf-dev \
+    libssl-dev \
     protobuf-compiler \
-    default-jre
+    python-pip \
+    python-zmq \
+    software-properties-common
 
 # Install Jupyter Notebook for iTorch
 RUN pip install notebook ipywidgets
@@ -33,7 +32,6 @@ ENV DYLD_LIBRARY_PATH=/root/torch/install/lib:$DYLD_LIBRARY_PATH
 ENV LUA_CPATH='/root/torch/install/lib/?.so;'$LUA_CPATH
 
 # Install cudnn manually as Torch opts for latest version
-#RUN luarocks install https://raw.githubusercontent.com/soumith/cudnn.torch/R4/cudnn-scm-1.rockspec
 RUN cd /root && \
     git clone https://github.com/deepmind/torch-hdf5.git && \
     cd torch-hdf5 && \
@@ -48,9 +46,12 @@ RUN wget https://github.com/hughperkins/FindCUDA/archive/v3.5-1.tar.gz -q -O Fin
 
 # Install additional DenseCap dependencies
 RUN luarocks install torch
+ENV CUDA_BIN_PATH=/usr/local/cuda-7.5
+RUN luarocks install cutorch
 RUN luarocks install nn
 RUN luarocks install image
 RUN luarocks install lua-cjson
+RUN luarocks install https://raw.githubusercontent.com/soumith/cudnn.torch/R4/cudnn-scm-1.rockspec
 RUN luarocks install https://raw.githubusercontent.com/qassemoquab/stnbhwd/master/stnbhwd-scm-1.rockspec
 RUN luarocks install https://raw.githubusercontent.com/jcjohnson/torch-rnn/master/torch-rnn-scm-1.rockspec
 RUN luarocks install loadcaffe
@@ -63,7 +64,6 @@ RUN apt-get update && apt-get install -y --no-install-recommends --force-yes \
         libcudnn5 \
         libcudnn5-dev && \
     rm -rf /var/lib/apt/lists/*
-ENV CUDA_BIN_PATH=/usr/local/cuda-7.5
 
 # GPU acceleratation
 RUN luarocks install cutorch


### PR DESCRIPTION
We accidentally borked the CUDA install by chaging `CUDA_VERSION` to use
a minor version, which broke the symlink. This is now fixed.

Additionally, we fix some build errors in the `Dockerfile.torch` by
copying over the lines we dropped from the old file. Unfortunately I do
not have time to pare it down to just the essentials, but the full build
now works.