### PR TITLE
Using set lookups instead of list lookups to improve performance

### DIFF
--- a/attalos/imgtxt_algorithms/correlation/correlation.py
+++ b/attalos/imgtxt_algorithms/correlation/correlation.py
@@ -14,7 +14,8 @@ def construct_W(w2v_model, vocab, dtype=np.float64):
     Returns:
         a numpy ndarray
     """
-    return np.asarray([w2v_model.get_vector(word) for word in vocab if word in w2v_model.vocab], dtype=dtype).T
+    w2v_vocab = set(w2v_model.vocab)
+    return np.asarray([w2v_model.get_vector(word) for word in vocab if word in w2v_vocab], dtype=dtype).T
 
 
 def get_invalid_labels(labels, valid_labels):

--- a/attalos/util/transformers/onehot.py
+++ b/attalos/util/transformers/onehot.py
@@ -32,7 +32,7 @@ class OneHot(TextTransformer):
 
     def create_data_mapping(self, *args, **kwargs):
         datasets = args[0]
-        valid_vocab = args[1]
+        valid_vocab = set(args[1])
         dataset_tags = set()
         if isinstance(datasets, collections.Iterable):
             iterable_datasets = datasets


### PR DESCRIPTION
This should greatly improve the performance when:
1) initializing OneHot transformer
2) calling construct_W()