### PR TITLE
Enable Log-Reg and Syntax Change (Hidden Units)

### DIFF
--- a/attalos/imgtxt_algorithms/approaches/fast0tag.py
+++ b/attalos/imgtxt_algorithms/approaches/fast0tag.py
@@ -22,7 +22,7 @@ class FastZeroTagModel(AttalosModel):
         self.w = construct_W(wv_model, self.one_hot.get_key_ordering()).T
         self.learning_rate = kwargs.get("learning_rate", 0.0001)
         self.optim_words = kwargs.get("optim_words", True)
-        self.hidden_units = kwargs.get("hidden_units", "200,200")
+        self.hidden_units = kwargs.get("hidden_units", "200")
         self.use_batch_norm = kwargs.get("use_batch_norm",False)
         if self.hidden_units=='0':                                                                                                  
             self.hidden_units=[]

--- a/attalos/imgtxt_algorithms/approaches/fast0tag.py
+++ b/attalos/imgtxt_algorithms/approaches/fast0tag.py
@@ -24,6 +24,7 @@ class FastZeroTagModel(AttalosModel):
         self.optim_words = kwargs.get("optim_words", True)
         self.hidden_units = kwargs.get("hidden_units", "200")
         self.use_batch_norm = kwargs.get("use_batch_norm",False)
+        self.opt_type = kwargs.get("opt_type","adam")
         if self.hidden_units=='0':                                                                                                  
             self.hidden_units=[]
         else:
@@ -94,7 +95,11 @@ class FastZeroTagModel(AttalosModel):
         loss = fztloss(self.model_info['prediction'], self.model_info['pos_vecs'], self.model_info['neg_vecs'])
         
         self.model_info['loss'] = loss
-        self.model_info['optimizer'] = tf.train.AdamOptimizer(learning_rate=self.learning_rate).minimize(loss)
+        if self.opt_type=='sgd':
+            optimizer=tf.train.GradientDescent
+        else:
+            optimizer=tf.train.AdamOptimizer
+        self.model_info['optimizer'] = optimizer(learning_rate=self.learning_rate).minimize(loss)                  
 
 
     def predict_feats(self, sess, x):

--- a/attalos/imgtxt_algorithms/approaches/naivesum.py
+++ b/attalos/imgtxt_algorithms/approaches/naivesum.py
@@ -30,7 +30,7 @@ class NaiveSumModel(AttalosModel):
 
         layers = []
         layer = model_info["input"]
-        for i, hidden_size in enumerate(hidden_units[:-1]):
+        for i, hidden_size in enumerate(hidden_units):
             layer = tf.contrib.layers.relu(layer, hidden_size)
             layers.append(layer)
         

--- a/attalos/imgtxt_algorithms/approaches/naivesum.py
+++ b/attalos/imgtxt_algorithms/approaches/naivesum.py
@@ -15,7 +15,7 @@ class NaiveSumModel(AttalosModel):
     This model performs linear regression via NN using the naive sum of word vectors as targets.
     """
     def _construct_model_info(self, input_size, output_size, learning_rate,
-                              hidden_units=[200,200]):
+                              hidden_units=[200]):
         logger.info("Input size: %s" % input_size)
         logger.info("Output size: %s" % output_size)
         

--- a/attalos/imgtxt_algorithms/approaches/negsampling.py
+++ b/attalos/imgtxt_algorithms/approaches/negsampling.py
@@ -16,7 +16,7 @@ class NegSamplingModel(AttalosModel):
     """
 
     def _construct_model_info(self, input_size, output_size, learning_rate, wv_arr,
-                              hidden_units=[200,200],
+                              hidden_units=[200],
                               optim_words=True,
                               use_batch_norm=True):
         model_info = {}
@@ -82,7 +82,7 @@ class NegSamplingModel(AttalosModel):
         self.optim_words = kwargs.get("optim_words", True)
         self.ignore_posbatch = kwargs.get("ignore_posbatch",False)
         self.joint_factor = kwargs.get("joint_factor",1.0)
-        self.hidden_units = kwargs.get("hidden_units", "200,200")
+        self.hidden_units = kwargs.get("hidden_units", "200")
         if self.hidden_units=='0':
             self.hidden_units=[]
         else:

--- a/attalos/imgtxt_algorithms/approaches/negsampling.py
+++ b/attalos/imgtxt_algorithms/approaches/negsampling.py
@@ -94,6 +94,11 @@ class NegSamplingModel(AttalosModel):
         self.negsampler = NegativeSampler(word_counts)
         train_dataset = datasets[0] # train_dataset should always be first in datasets
         self.w = construct_W(wv_model, self.one_hot.get_key_ordering()).T
+        scale_words = kwargs.get("scale_words",1.0)
+        if scale_words == 0.0:
+            self.w = (self.w.T / np.linalg.norm(self.w,axis=1)).T
+        else:
+            self.w *= scale_words
 
         # Optimization parameters
         # Starting learning rate, currently default to 0.001. This will change iteratively if decay is on.
@@ -131,7 +136,7 @@ class NegSamplingModel(AttalosModel):
             
         # This will decay the learning rate every ten epochs. Hardcoded ten currently...
         if self.weight_decay:
-            if self.epoch_num and self.epoch_num % 10 == 0:
+            if self.epoch_num and self.epoch_num % 15 == 0 and self.learning_rate > 1e-6:
                 self.learning_rate *= self.weight_decay
         	logger.info('Learning rate dropped to {}'.format(self.learning_rate))
             self.epoch_num+=1

--- a/attalos/imgtxt_algorithms/main.py
+++ b/attalos/imgtxt_algorithms/main.py
@@ -201,7 +201,7 @@ def main():
     # new args
     parser.add_argument("--hidden_units",
                         type=str,
-                        default="200,200",
+                        default="200",
                         help="Define a neural network as comma separated layer sizes")
     parser.add_argument("--cross_eval",
                         action="store_true",
@@ -231,6 +231,10 @@ def main():
                         type=float,
                         default=1.0,
                         help="Multiplier for learning rate in updating joint optimization")
+    parser.add_argument("--use_batch_norm",
+                        action="store_true",
+                        default=False,
+                        help="Do we want to use batch normalization?")
 
 
     args = parser.parse_args()

--- a/attalos/imgtxt_algorithms/main.py
+++ b/attalos/imgtxt_algorithms/main.py
@@ -243,6 +243,14 @@ def main():
                         type=float,
                         default=0.0,
                         help="Weight decay to manually decay every 10 epochs. Default=0 for no decay.")
+    parser.add_argument("--scale_words",
+                        type=float,
+                        default=1.0,
+                        help="Scale the word vectors. If set to zero, scale by L2-norm. Otherwise, wordvec=scale x wordvec")
+    parser.add_argument("--scale_images",
+                        type=float,
+                        default=1.0,
+                        help="Scale the word vectors. If set to zero, scale by L2-norm. Otherwise, imvec=scale x imvec. ")
 
     args = parser.parse_args()
 

--- a/attalos/imgtxt_algorithms/main.py
+++ b/attalos/imgtxt_algorithms/main.py
@@ -202,7 +202,7 @@ def main():
     parser.add_argument("--hidden_units",
                         type=str,
                         default="200",
-                        help="Define a neural network as comma separated layer sizes")
+                        help="Define a neural network as comma separated layer sizes. If log-reg, then set to '0'.")
     parser.add_argument("--cross_eval",
                         action="store_true",
                         default=False,
@@ -234,8 +234,15 @@ def main():
     parser.add_argument("--use_batch_norm",
                         action="store_true",
                         default=False,
-                        help="Do we want to use batch normalization?")
-
+                        help="Do we want to use batch normalization? Default is False")
+    parser.add_argument("--opt_type",
+                        type=str,
+                        default="adam",
+                        help="What type of optimizer would you like? Choices are (adam,sgd)")
+    parser.add_argument("--weight_decay",
+                        type=float,
+                        default=0.0,
+                        help="Weight decay to manually decay every 10 epochs. Default=0 for no decay.")
 
     args = parser.parse_args()
 


### PR DESCRIPTION
Changes the syntax so that the following will be true:
                                                                                                                                    
    Input Feature Dimensionality: 2048                                                                                              
    Output WordVec Dimensionality: 200                                                                                              
    Hidden Units: 12345,12345                                                                                                       
                                                                                                                                    
    This will produce a network that looks like this:                                                                               
                                                                                                                                    
    2048 -> 12345 -> 12345 -> 200

Previously, the network would have given an error.

This commit will fix the bug where the user happens to run simple logistic regression (i.e., no hidden units). 

Other changes:
Reset the defaults to have the hidden unit be a single 200 layer for consistency. The output layer is still 200, essentially mak

