### PR TITLE
Readme cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,11 +30,6 @@ make
 - Docker
 - make
 
-# Documentation
-
-- [Docs](https://github.com/Lab41/attalos/tree/master/docs)
-
-
 # Contributing to Attalos
 
 Want to contribute?  Awesome!  Issue a pull request or see more details [here](https://github.com/Lab41/attalos/blob/master/CONTRIBUTING.md).

--- a/README.md
+++ b/README.md
@@ -29,14 +29,6 @@ make run
 # Documentation
 - [Docs](https://github.com/Lab41/attalos/tree/master/docs)
 
-# Tests
-
-Tests are currently written in py.test for Python.  The tests are automatically run when building the dockerfile.
-
-They can also be tested using:
-```
-make test
-```
 
 # Contributing to Attalos
 

--- a/README.md
+++ b/README.md
@@ -6,15 +6,15 @@ This project explores methods in constructing a common representation across mod
 
 To start downloading datasets, see [the Dataset README](attalos/dataset/README.md).
 
-To learn about running the performance metrics, see [the Evaluation README](attalos/dataset/README.md).
+To learn how to preprocess data, see [the Preprocessing READE](attalos/preprocessing/README.md).
 
-To learn how to run the demo app, see [the Demo README](attalos/imgtxt_algorithms/demo_app/README.md).
+To learn about running the performance metrics, see [the Evaluation README](attalos/dataset/README.md).
 
 To learn how to optimize wordvectors, see [the Update-words README](attalos/imgtxt_algorithms/updatewords/README.md).
 
-To learn about our utilities classes, see [the Util README](attalos/imgtxt_algorithms/util/README.md).
+To learn how to run the demo app, see [the Demo README](attalos/imgtxt_algorithms/demo_app/README.md).
 
-To learn how to pre-process MSCOCO, see [the MSCOCO READE](attalos/preprocessing/README.md).
+To learn about our utilities classes, see [the Util README](attalos/imgtxt_algorithms/util/README.md).
 
 
 # Install Instructions

--- a/README.md
+++ b/README.md
@@ -30,12 +30,6 @@ make
 - Docker
 - make
 
-# Usage Examples
-
-```
-make run
-```
-
 # Documentation
 
 - [Docs](https://github.com/Lab41/attalos/tree/master/docs)

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ This project explores methods in constructing a common representation across mod
 
 To start downloading datasets, see [the Dataset README](attalos/dataset/README.md).
 
-To learn about running the performance metrics, see [the Evaluation README](attalos/attalos/dataset/README.md).
+To learn about running the performance metrics, see [the Evaluation README](attalos/dataset/README.md).
 
 To learn how to run the demo app, see [the Demo README](attalos/imgtxt_algorithms/demo_app/README.md).
 

--- a/README.md
+++ b/README.md
@@ -2,10 +2,20 @@
 
 This project explores methods in constructing a common representation across modalities using unstructured and heterogeneous data collections. This representation will be a joint vector space that can be used to compare concepts in a numerical manner, no matter how different the modality or type of concepts are. The type of data can vary widely and will range from images to text to social structure, but comparisons between them will be seamless and can be made with Euclidean operations. In other words, concepts that are proximal in the joint vector space will be exhibit semantic similarity. Lab41 will evaluate the vector space using well-known metrics on classification tasks.
 
-
 # Getting Started
 
-Nothing to see here yet, move along...
+To start downloading datasets, see [the Dataset README](attalos/dataset/README.md).
+
+To learn about running the performance metrics, see [the Evaluation README](attalos/attalos/dataset/README.md).
+
+To learn how to run the demo app, see [the Demo README](attalos/imgtxt_algorithms/demo_app/README.md).
+
+To learn how to optimize wordvectors, see [the Update-words README](attalos/imgtxt_algorithms/updatewords/README.md).
+
+To learn about our utilities classes, see [the Util README](attalos/imgtxt_algorithms/util/README.md).
+
+To learn how to pre-process MSCOCO, see [the MSCOCO READE](attalos/preprocessing/README.md).
+
 
 # Install Instructions
 
@@ -27,6 +37,7 @@ make run
 ```
 
 # Documentation
+
 - [Docs](https://github.com/Lab41/attalos/tree/master/docs)
 
 


### PR DESCRIPTION
Some updates to the README including:

- Removal of the tests section (we don't have tests)
- Removal of the `make run` directions (we don't have a run target)
- Removal of the Documentation link (we don't have /docs)
- Added links to REAMEs scattered throughout the project